### PR TITLE
Apply styling to trials#index

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,9 +1,43 @@
 @charset "utf-8";
-
-@import "normalize-rails";
-
 @import "bourbon";
-@import "neat";
 
-@import "base/base";
-@import "refills/flashes";
+#trial-match {
+  @import "base/base";
+
+  .trial-base-container {
+    display: flex;
+  }
+
+  .trial-sidebar {
+    background-color: $light-gray;
+    border: $base-border;
+    flex: 1;
+    padding: $large-spacing;
+
+    &::before {
+      content: "";
+      display: none;
+    }
+  }
+
+  .trial-sidebar-search-parameters {
+    padding: 0;
+  }
+
+  .form-actions {
+    @include margin($base-spacing null);
+  }
+
+  .trial-results {
+    @include padding($large-spacing);
+    flex: 2;
+  }
+
+  .trial-count {
+    text-align: right;
+  }
+
+  .trial-list li {
+    border-bottom: $base-border;
+  }
+}

--- a/app/assets/stylesheets/base/_base.scss
+++ b/app/assets/stylesheets/base/_base.scss
@@ -3,14 +3,12 @@
 // Copyright 2013-2015 thoughtbot, inc.
 // MIT License
 
-#trial-match {
-  @import "variables";
+@import "variables";
 
-  @import "buttons";
-  @import "forms";
-  @import "layout";
-  @import "lists";
-  @import "media";
-  @import "tables";
-  @import "typography";
-}
+@import "buttons";
+@import "forms";
+@import "layout";
+@import "lists";
+@import "media";
+@import "tables";
+@import "typography";

--- a/app/assets/stylesheets/base/_forms.scss
+++ b/app/assets/stylesheets/base/_forms.scss
@@ -13,7 +13,6 @@ legend {
 
 label {
   display: block;
-  font-weight: 600;
   margin-bottom: $small-spacing / 2;
 }
 
@@ -23,6 +22,7 @@ textarea {
   display: block;
   font-family: $base-font-family;
   font-size: $base-font-size;
+  height: $large-spacing;
 }
 
 #{$all-text-inputs},
@@ -72,7 +72,13 @@ textarea {
 [type="checkbox"],
 [type="radio"] {
   display: inline;
-  margin-right: $small-spacing / 2;
+  margin-right: $small-spacing;
+}
+
+.radio {
+  align-items: center;
+  display: flex;
+  margin-left: $small-spacing;
 }
 
 [type="file"] {
@@ -84,4 +90,9 @@ select {
   margin-bottom: $small-spacing;
   max-width: 100%;
   width: auto;
+}
+
+abbr[title] {
+  border: 0;
+  color: $alert-color;
 }

--- a/app/assets/stylesheets/base/_layout.scss
+++ b/app/assets/stylesheets/base/_layout.scss
@@ -6,4 +6,5 @@ html {
 *::before,
 *::after {
   box-sizing: inherit;
+  line-height: $base-line-height;
 }

--- a/app/assets/stylesheets/base/_variables.scss
+++ b/app/assets/stylesheets/base/_variables.scss
@@ -9,25 +9,28 @@ $heading-font-family: $base-font-family;
 // Font Sizes
 $base-font-size: 1em;
 
-// Line height
-$base-line-height: 1.5;
-$heading-line-height: 1.2;
-
 // Other Sizes
 $base-border-radius: 3px;
-$base-spacing: $base-line-height * 1em;
+$base-spacing: 1em;
+$large-spacing: $base-spacing * 2;
 $small-spacing: $base-spacing / 2;
 $base-z-index: 0;
+
+// Line height
+$base-line-height: $base-spacing * 1.2;
+$heading-line-height: 1.2;
 
 // Colors
 $blue: #1565c0;
 $dark-gray: #333;
+$light-gray: #f6f6f6;
 $medium-gray: #999;
-$light-gray: #ddd;
+$red: #f00;
 
 // Font Colors
 $base-font-color: $dark-gray;
 $action-color: $blue;
+$alert-color: $red;
 
 // Border
 $base-border-color: $light-gray;

--- a/app/views/application/_site_html_top_half.html.erb
+++ b/app/views/application/_site_html_top_half.html.erb
@@ -120,9 +120,7 @@
 <header class="article-header">
   <div class="wrapper">
     
-    <nav class="breadcrumbs"><a href="http://braintumor.org"> www.braintumor.org</a> <span class="breadcrumbseparator"> > </span> <a href="http://braintumor.org/information">Brain Tumor Information</a><span class="breadcrumbseparator"> > </span><a href="http://braintumor.org/brain-tumor-information/treatment-options/" title="">Treatment Options</a><span class="breadcrumbseparator"> > </span>Clinical Trials</nav>
-
-    <h9>Clinical Trials</h9>
+    <h1>Clinical Trial Finder</h1>
     <p></p>
 
     <div id="sharebarDiv"></div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,8 +18,10 @@
 </head>
 <body class="<%= body_class %>">
   <%= render "site_html_top_half" %>
-  <div id="trial-match">
-    <%= yield %>
+  <div id="trial-match" class="columns wrapper">
+    <div class="trial-base-container">
+      <%= yield %>
+    </div>
   </div>
   <%= render "site_html_bottom_half" %>
   <%= render "javascript" %>

--- a/app/views/trials/_search_filter.html.erb
+++ b/app/views/trials/_search_filter.html.erb
@@ -1,27 +1,39 @@
-<%= simple_form_for :trial_filter, method: :get do |f| %>
-  <%= f.input :keyword, filter_input_default(:keyword) %>
-  <%= f.input :zip_code, filter_input_default(:zip_code) %>
-  <%= f.input(
-    :distance_radius,
-    as: :select,
-    collection: distance_radius_options,
-    selected: distance_radius_selected_value
-  ) %>
-  <%= f.input :age, filter_input_default(:age) %>
-  <%= f.input(
-    :gender,
-    filter_radio_default(:gender).merge(
-      as: :radio_buttons,
-      collection: ["Male", "Female"]
-    )
-  ) %>
-  <%= f.input(
-    :control,
-    filter_radio_default(:control).merge(
-      as: :radio_buttons,
-      collection: control_options,
-      label: false
-    )
-  ) %>
-  <%= f.submit t(".submit") %>
-<% end %>
+<div class="trial-sidebar">
+  <section class="trial-sidebar-search-parameters">
+    <h2><%= title %></h2>
+    <%= simple_form_for :trial_filter, method: :get do |f| %>
+      <%= f.input :keyword, filter_input_default(:keyword) %>
+      <%= f.input :zip_code, filter_input_default(:zip_code) %>
+
+      <%= f.input(
+        :distance_radius,
+        as: :select,
+        collection: distance_radius_options,
+        selected: distance_radius_selected_value
+      ) %>
+
+      <%= f.input :age, filter_input_default(:age) %>
+
+      <%= f.input(
+        :gender,
+        filter_radio_default(:gender).merge(
+          as: :radio_buttons,
+          collection: ["Male", "Female"]
+        )
+      ) %>
+
+      <%= f.input(
+        :control,
+        filter_radio_default(:control).merge(
+          as: :radio_buttons,
+          collection: control_options,
+          label: t("simple_form.labels.trials.index.control"),
+        )
+      ) %>
+
+      <div class="form-actions">
+        <%= f.submit t(".submit"), class: "donate-link btn btn-orange" %>
+      </div>
+    <% end %>
+  </section>
+</div>

--- a/app/views/trials/_trial.html.erb
+++ b/app/views/trials/_trial.html.erb
@@ -1,7 +1,11 @@
-<div>
-  <%= link_to trial.title, trial_path(trial) %>
-  <div><%= "#{trial.minimum_age_original} - #{trial.maximum_age_original}" %></div>
-  <% if zip_code_param.present? %>
-    <%= render "closest_site", closest_site: trial.closest_site(zip_code_param) %>
-  <% end %>
-</div>
+<li>
+  <article>
+    <h3><%= link_to trial.title, trial_path(trial) %></h3>
+    <p><%= trial.description %></p>
+    <p><%= "#{trial.minimum_age_original} - #{trial.maximum_age_original}" %></p>
+    <% if zip_code_param.present? %>
+      <%= render "closest_site", closest_site: trial.closest_site(zip_code_param) %>
+    <% end %>
+    <p><%= link_to "Learn More", trial_path(trial), class: "more" %></p>
+  </article>
+</li>

--- a/app/views/trials/_trial_count.html.erb
+++ b/app/views/trials/_trial_count.html.erb
@@ -1,1 +1,3 @@
-<%= t(".displaying", count: @trials.count) %>
+<div class="trial-count">
+  <%= t(".displaying", count: @trials.count) %>
+</div>

--- a/app/views/trials/index.html.erb
+++ b/app/views/trials/index.html.erb
@@ -1,16 +1,18 @@
-<h1><%= title %></h1>
-
 <%= render "search_filter" %>
 
-<% if @trials.empty? %>
-  <%= render "empty_results" %>
-<% else %>
+<main class="trial-results">
+  <% if @trials.empty? %>
+    <%= render "empty_results" %>
+  <% else %>
 
-  <%= render "trial_count" %>
+    <%= render "trial_count" %>
 
-  <%= render @trials %>
+    <ol class="trial-list feature-list">
+      <%= render @trials %>
+    </ol>
 
-  <%= render "pagination" %>
+    <%= render "pagination" %>
 
-  <%= render "clinicaltrials_gov_logo" %>
-<% end %>
+    <%= render "clinicaltrials_gov_logo" %>
+  <% end %>
+</main>

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -58,7 +58,7 @@ SimpleForm.setup do |config|
   # Defaults to :nested for bootstrap config.
   #   inline: input + label
   #   nested: label > input
-  config.boolean_style = :nested
+  config.boolean_style = :inline
 
   # Default class for buttons
   config.button_class = 'btn'
@@ -91,13 +91,13 @@ SimpleForm.setup do |config|
 
   # You can wrap each item in a collection of radio/check boxes with a tag,
   # defaulting to :span.
-  # config.item_wrapper_tag = :span
+  config.item_wrapper_tag = :div
 
   # You can define a class to use in all item wrappers. Defaulting to none.
   # config.item_wrapper_class = nil
 
   # How the label text should be generated altogether with the required text.
-  # config.label_text = lambda { |label, required, explicit_label| "#{required} #{label}" }
+  config.label_text = ->(label, required, _explicit_label) { "#{label}" "#{required}" }
 
   # You can define the class to use on all labels. Default is nil.
   # config.label_class = nil

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,7 +45,7 @@ en:
     frequently_asked_questions:
       index: "Overview & Frequently Asked Questions"
     trials:
-      index: "Search Trials"
+      index: "Filters"
   trials:
     clinicaltrials_gov_logo:
       trials_imported: "Trials imported on %{timestamp} from:"

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -11,7 +11,10 @@ en:
     error_notification:
       default_message: "Please review the problems below:"
     # Examples
-    # labels:
+    labels:
+      trials:
+        index:
+          control: "Patient or control?"
     #   defaults:
     #     password: 'Password'
     #   user:


### PR DESCRIPTION
Rather than applying new styles and fighting the existing template, it
was easier to model this page off of a few existing pages on the
National Brain Tumor site and work with the existing class structure.

Pages for Reference:
http://braintumor.org/join-the-fight/ways-to-give/
http://braintumor.org/join-the-fight/volunteer/

https://github.com/mwenger1/trial-match/issues/17

STILL TO DO:

* Style form inputs
* Trim description text with ellipsis

<img width="1250" alt="screen shot 2016-08-14 at 8 29 49 pm" src="https://cloud.githubusercontent.com/assets/1781967/17653236/035bf2ea-6260-11e6-98fb-5aece828b3c9.png">
