### PR TITLE
Pagination always fits on single line

### DIFF
--- a/app/assets/stylesheets/base/_pagination.scss
+++ b/app/assets/stylesheets/base/_pagination.scss
@@ -1,7 +1,7 @@
 .apple-pagination {
   background: $light-gray;
   border: $base-border-width solid $medium-gray;
-  padding: 1em;
+  padding: $base-spacing $small-spacing;
   text-align: center;
 
   a,

--- a/app/views/trials/_pagination.html.erb
+++ b/app/views/trials/_pagination.html.erb
@@ -1,5 +1,5 @@
-<% if @trials.count > 10 %>
+<% if @trials.count > WillPaginate.per_page %>
   <div class="pagination-panel apple-pagination">
-    <%= will_paginate @trials, :container =>false %>
+    <%= will_paginate @trials, container: false, inner_window: 3, outer_window: 0 %>
   </div>
 <% end %>


### PR DESCRIPTION
* Use global variable instead of hardcoded integer

https://github.com/mwenger1/trial-match/issues/68

<img width="676" alt="screen shot 2016-10-04 at 7 51 35 am" src="https://cloud.githubusercontent.com/assets/1781967/19073208/cb3ff4e0-8a07-11e6-8ca5-fd570f6acf3b.png">
<img width="678" alt="screen shot 2016-10-04 at 7 51 30 am" src="https://cloud.githubusercontent.com/assets/1781967/19073209/cb412f90-8a07-11e6-938b-abfb3a1e59fa.png">
<img width="655" alt="screen shot 2016-10-04 at 7 51 25 am" src="https://cloud.githubusercontent.com/assets/1781967/19073210/cb4be0ca-8a07-11e6-8afd-d79073831351.png">
